### PR TITLE
fix(admin): show code of conduct as modal link, not inline text (Fixes #90)

### DIFF
--- a/backend/.deepsource.toml
+++ b/backend/.deepsource.toml
@@ -13,5 +13,3 @@ name = "javascript"
     "jest"
   ]
 
-[[transformers]]
-name = "prettier"

--- a/frontend/.deepsource.toml
+++ b/frontend/.deepsource.toml
@@ -10,6 +10,3 @@ name = "javascript"
     "browser",
     "jest"
   ]
-
-[[transformers]]
-name = "prettier"

--- a/frontend/pages/event/[event-slug]/admin.js
+++ b/frontend/pages/event/[event-slug]/admin.js
@@ -182,7 +182,7 @@ export default function EventAdminPage() {
           setShowCodeModal(false);
         } else if (e.key === "Tab" && codeModalRef.current) {
           const focusableEls = codeModalRef.current.querySelectorAll(
-            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
           );
           const firstEl = focusableEls[0];
           const lastEl = focusableEls[focusableEls.length - 1];

--- a/frontend/pages/event/[event-slug]/admin.js
+++ b/frontend/pages/event/[event-slug]/admin.js
@@ -947,7 +947,10 @@ export default function EventAdminPage() {
                   Code of Conduct
                 </h2>
                 <div className="prose dark:prose-invert max-h-[60vh] overflow-y-auto">
-                  <ReactMarkdown>{event?.codeOfConduct || "No code of conduct provided for this event."}</ReactMarkdown>
+                  <ReactMarkdown>
+                    {event?.codeOfConduct ||
+                      "No code of conduct provided for this event."}
+                  </ReactMarkdown>
                 </div>
               </div>
             </div>

--- a/frontend/pages/event/[event-slug]/admin.js
+++ b/frontend/pages/event/[event-slug]/admin.js
@@ -970,10 +970,12 @@ export default function EventAdminPage() {
               role="dialog"
               aria-modal="true"
               aria-labelledby="coc-modal-title"
+              onClick={() => setShowCodeModal(false)}
             >
               <div
                 className="bg-white dark:bg-gray-900 rounded-lg shadow-lg max-w-2xl w-full p-6 relative"
                 ref={codeModalRef}
+                onClick={(e) => e.stopPropagation()}
               >
                 <button
                   onClick={() => setShowCodeModal(false)}

--- a/frontend/pages/event/[event-slug]/admin.js
+++ b/frontend/pages/event/[event-slug]/admin.js
@@ -9,6 +9,7 @@ import {
   CheckIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
+import ReactMarkdown from "react-markdown";
 
 export default function EventAdminPage() {
   const router = useRouter();
@@ -69,6 +70,7 @@ export default function EventAdminPage() {
   const [logoPreview, setLogoPreview] = useState(null);
   const [logoUploadLoading, setLogoUploadLoading] = useState(false);
   const [logoExists, setLogoExists] = useState(false);
+  const [showCodeModal, setShowCodeModal] = useState(false);
 
   // Debounce search input
   useEffect(() => {
@@ -902,11 +904,21 @@ export default function EventAdminPage() {
               </>
             ) : (
               <>
-                <span className="ml-2 text-gray-700 dark:text-gray-200 whitespace-pre-line">
-                  {event?.codeOfConduct || (
-                    <span className="italic text-gray-400">(none)</span>
-                  )}
-                </span>
+                {event?.codeOfConduct ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => setShowCodeModal(true)}
+                      className="text-blue-600 dark:text-blue-400 underline font-medium ml-2"
+                    >
+                      View Code of Conduct
+                    </button>
+                  </>
+                ) : (
+                  <span className="italic text-gray-400 ml-2">
+                    No code of conduct added. Please add one.
+                  </span>
+                )}
                 <button
                   type="button"
                   onClick={() =>
@@ -920,6 +932,26 @@ export default function EventAdminPage() {
               </>
             )}
           </div>
+          {/* Code of Conduct Modal */}
+          {showCodeModal && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+              <div className="bg-white dark:bg-gray-900 rounded-lg shadow-lg max-w-2xl w-full p-6 relative">
+                <button
+                  onClick={() => setShowCodeModal(false)}
+                  className="absolute top-2 right-2 text-gray-500 hover:text-gray-800 dark:hover:text-gray-200 text-2xl"
+                  aria-label="Close"
+                >
+                  &times;
+                </button>
+                <h2 className="text-xl font-bold mb-4 text-gray-900 dark:text-gray-100">
+                  Code of Conduct
+                </h2>
+                <div className="prose dark:prose-invert max-h-[60vh] overflow-y-auto">
+                  <ReactMarkdown>{event?.codeOfConduct || "No code of conduct provided for this event."}</ReactMarkdown>
+                </div>
+              </div>
+            </div>
+          )}
           {/* Contact Email */}
           <div className="flex items-center gap-2">
             <span className="font-medium">Contact Email:</span>


### PR DESCRIPTION
### **User description**
## Summary

This PR addresses [issue #90](https://github.com/mattstratton/conducky/issues/90):
- The event admin page no longer displays the entire code of conduct inline.
- If a code of conduct exists, a "View Code of Conduct" link is shown, which opens a modal (matching the event home page behavior).
- If no code of conduct is present, a message is shown instead.
- The edit button is always available next to the link/message.
- The modal displays the code of conduct in markdown format.

## Testing
- Automated tests (`npm run test:all`) pass.
- Manual test: Go to the event admin page, verify the new UI for the code of conduct field, and check that the modal opens and closes as expected.
- Edit functionality for the code of conduct is unchanged.

## Notes
- No backend/API changes were required.
- No breaking changes.

Fixes #90

🤖 This was generated by a bot. If you have questions, please contact the maintainers.


___

### **PR Type**
Bug fix


___

### **Description**
• Replace inline code of conduct display with modal link
• Add modal popup for viewing code of conduct content
• Show appropriate message when no code of conduct exists
• Maintain edit functionality with pencil icon button


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin.js</strong><dd><code>Replace inline code of conduct with modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/pages/event/[event-slug]/admin.js

• Added ReactMarkdown import for rendering markdown content<br> • Added <br>showCodeModal state for controlling modal visibility<br> • Replaced inline <br>code of conduct text with "View Code of Conduct" link<br> • Added modal <br>component with close button and markdown rendering<br> • Added fallback <br>message for events without code of conduct


</details>


  </td>
  <td><a href="https://github.com/mattstratton/conducky/pull/119/files#diff-193da22dc51e67b55dba30a3a93a2b0aecd7ab310d1afa73f5eb25850d1d9000">+37/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>