### PR TITLE
Implement public system settings endpoint and update legacy route

### DIFF
--- a/backend/__mocks__/@prisma/client.js
+++ b/backend/__mocks__/@prisma/client.js
@@ -1439,7 +1439,14 @@ class PrismaClient {
       }),
     };
     this.systemSetting = {
-      findMany: jest.fn(() => [...inMemoryStore.systemSettings]),
+      findMany: jest.fn(({ where } = {}) => {
+        let results = [...inMemoryStore.systemSettings];
+        if (where && where.key && where.key.in) {
+          // Filter by key array (for public settings)
+          results = results.filter(s => where.key.in.includes(s.key));
+        }
+        return results;
+      }),
       findUnique: jest.fn(({ where }) => {
         return inMemoryStore.systemSettings.find(s => s.key === where.key) || null;
       }),

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -211,11 +211,36 @@ app.get('/api/session', async (req: any, res: any) => {
   }
 });
 
-// System settings route (frontend expects /api/system/settings)
+// Public system settings route (only safe settings, no authentication required)
+app.get('/api/system/settings/public', async (_req: any, res: any) => {
+  try {
+    // Only expose safe, public settings
+    const publicSettings = ['showPublicEventList'];
+    const settings = await prisma.systemSetting.findMany({
+      where: { key: { in: publicSettings } }
+    });
+    
+    // Convert array to object for easier frontend usage
+    const settingsObj: Record<string, string> = {};
+    settings.forEach(setting => {
+      settingsObj[setting.key] = setting.value;
+    });
+    
+    res.json({ settings: settingsObj });
+  } catch (err: any) {
+    res.status(500).json({ error: 'Failed to fetch public system settings', details: err.message });
+  }
+});
+
+// Legacy endpoint for backward compatibility - redirects to public endpoint
+// TODO: Remove this after frontend is updated
 app.get('/api/system/settings', async (_req: any, res: any) => {
   try {
-    // Get system settings from database
-    const settings = await prisma.systemSetting.findMany();
+    // Only expose safe, public settings for backward compatibility
+    const publicSettings = ['showPublicEventList'];
+    const settings = await prisma.systemSetting.findMany({
+      where: { key: { in: publicSettings } }
+    });
     
     // Convert array to object for easier frontend usage
     const settingsObj: Record<string, string> = {};

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -301,6 +301,31 @@ router.get('/events/stats', requireSuperAdmin(), async (req: Request, res: Respo
 });
 
 /**
+ * GET /api/admin/system/settings
+ * Get all system settings (SuperAdmin only)
+ */
+router.get('/system/settings', requireSuperAdmin(), async (req: Request, res: Response): Promise<void> => {
+  try {
+    // Get all system settings from database
+    const settings = await prisma.systemSetting.findMany();
+    
+    // Convert array to object for easier frontend usage
+    const settingsObj: Record<string, string> = {};
+    settings.forEach(setting => {
+      settingsObj[setting.key] = setting.value;
+    });
+    
+    res.json({ settings: settingsObj });
+  } catch (err: any) {
+    console.error('Error fetching admin system settings:', err);
+    res.status(500).json({ 
+      error: 'Failed to fetch system settings', 
+      details: err.message 
+    });
+  }
+});
+
+/**
  * PATCH /api/admin/system/settings
  * Update system settings (SuperAdmin only)
  */

--- a/frontend/pages/admin/system/settings.tsx
+++ b/frontend/pages/admin/system/settings.tsx
@@ -28,7 +28,7 @@ export default function SystemSettings() {
     try {
       setLoading(true);
       const response = await fetch(
-        (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000') + '/api/system/settings',
+        (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000') + '/api/admin/system/settings',
         { credentials: 'include' }
       );
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -57,7 +57,7 @@ export default function Home() {
   useEffect(() => {
     async function fetchSettingsAndEvents() {
       try {
-        const res = await fetch((process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000') + '/api/system/settings');
+        const res = await fetch((process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000') + '/api/system/settings/public');
         const data = await res.json();
         if (data.settings && data.settings.showPublicEventList === 'true') {
           setShowEventList(true);


### PR DESCRIPTION
Fixes #160

- Added a new public endpoint `/api/system/settings/public` to expose only safe system settings without authentication.
- Updated the legacy `/api/system/settings` endpoint to maintain backward compatibility while still returning only public settings.
- Introduced an admin route `/api/admin/system/settings` for SuperAdmin access to all system settings.
- Updated integration tests to reflect changes in endpoint access and ensure proper functionality.
- Modified frontend components to fetch settings from the new public endpoint.
