### PR TITLE
Add default unified roles migration for first-time installations

### DIFF
--- a/backend/prisma/migrations/20250812140239_add_default_unified_roles/migration.sql
+++ b/backend/prisma/migrations/20250812140239_add_default_unified_roles/migration.sql
@@ -1,3 +1,6 @@
+-- Ensure gen_random_uuid() is available on fresh databases
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 -- Insert default unified roles needed for system functionality
 -- This ensures roles exist before any user registration attempts
 


### PR DESCRIPTION
### **User description**
Fixes #325

- Introduced a new SQL migration file to insert default unified roles into the database, ensuring essential roles are available prior to user registration.
- The roles include system_admin, org_admin, org_viewer, event_admin, responder, and reporter, each with specific scopes and levels.
- Implemented an ON CONFLICT clause to prevent duplicate role entries based on the role name.


___

### **PR Type**
Bug fix


___

### **Description**
- Add database migration for default unified roles

- Ensure essential roles exist before user registration

- Prevent duplicate role entries with conflict handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Migration Script"] --> B["UnifiedRole Table"]
  B --> C["Default Roles Created"]
  C --> D["system_admin (level 100)"]
  C --> E["org_admin (level 50)"]
  C --> F["event_admin (level 40)"]
  C --> G["responder (level 20)"]
  C --> H["org_viewer (level 10)"]
  C --> I["reporter (level 5)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migration.sql</strong><dd><code>Add default unified roles migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/prisma/migrations/20250812140239_add_default_unified_roles/migration.sql

<ul><li>Creates new database migration file<br> <li> Inserts 6 default unified roles with different scopes and levels<br> <li> Uses <code>ON CONFLICT</code> clause to prevent duplicate entries<br> <li> Includes roles for system, organization, and event scopes</ul>


</details>


  </td>
  <td><a href="https://github.com/mattstratton/conducky/pull/403/files#diff-49b068c661463c01981ca65ee637bd21d1966d3408022d04c7282b8bd63a9ce0">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

