### PR TITLE
Implement Reopen Incident functionality

### DIFF
--- a/backend/src/routes/event/incidents.routes.ts
+++ b/backend/src/routes/event/incidents.routes.ts
@@ -560,6 +560,67 @@ router.patch('/:incidentId/state', requireRole(['responder', 'event_admin', 'sys
     }
 });
 
+// Reopen incident
+router.patch('/:incidentId/reopen', requireRole(['responder', 'event_admin', 'system_admin']), async (req: Request, res: Response): Promise<void> => {
+    try {
+        const { eventId, incidentId, slug } = req.params;
+        const { notes, assignedToUserId } = req.body as { notes?: string; assignedToUserId?: string };
+        const user = req.user as any;
+
+        if (!notes || typeof notes !== 'string' || notes.trim().length === 0) {
+            res.status(400).json({ error: 'Notes are required to reopen an incident.' });
+            return;
+        }
+
+        let currentEventId = eventId;
+        if (slug) {
+            const eventIdFromSlug = await eventService.getEventIdBySlug(slug);
+            if (!eventIdFromSlug) {
+                res.status(404).json({ error: 'Event not found.' });
+                return;
+            }
+            currentEventId = eventIdFromSlug;
+        }
+
+        // Fetch incident to validate current state and access
+        const incidentResult = await incidentService.getIncidentById(incidentId);
+        if (!incidentResult.success || !incidentResult.data) {
+            res.status(404).json({ error: 'Incident not found.' });
+            return;
+        }
+        const incident = incidentResult.data.incident as any;
+        if (incident.eventId !== currentEventId) {
+            res.status(404).json({ error: 'Incident not found for this event.' });
+            return;
+        }
+
+        const canEditResult = await incidentService.checkIncidentEditAccess(user.id, incidentId, currentEventId);
+        if (!canEditResult.success || !canEditResult.data?.canEdit) {
+            res.status(403).json({ error: canEditResult.error || 'You are not authorized to reopen this incident.' });
+            return;
+        }
+
+        if (!['resolved', 'closed'].includes(incident.state)) {
+            res.status(400).json({ error: 'Only resolved or closed incidents can be reopened.' });
+            return;
+        }
+
+        // Branching: if assignedToUserId provided, go to investigating (requires assignment handled by service rules)
+        // otherwise go to acknowledged
+        const targetState = assignedToUserId ? 'investigating' : 'acknowledged';
+
+        const result = await incidentService.updateIncidentState(currentEventId, incidentId, targetState, user.id, notes, assignedToUserId);
+
+        if (result.success) {
+            res.json(result.data);
+        } else {
+            res.status(400).json({ error: result.error });
+        }
+    } catch (error: any) {
+        logger().error('Reopen incident error:', error);
+        res.status(500).json({ error: 'Failed to reopen incident.' });
+    }
+});
 
 // Update incident description
 router.patch('/:incidentId/description', requireRole(['reporter', 'responder', 'event_admin', 'system_admin']), async (req: Request, res: Response): Promise<void> => {

--- a/backend/tests/integration/enhanced-state-management.test.js
+++ b/backend/tests/integration/enhanced-state-management.test.js
@@ -80,6 +80,71 @@ describe('Enhanced State Management API', () => {
     });
   });
 
+  describe('Reopen Incident Endpoint', () => {
+    it('should reopen a closed incident to acknowledged when no assignee and notes provided', async () => {
+      // Ensure r1 exists and set it to closed first (SuperAdmin user default)
+      await request(app)
+        .patch('/api/events/1/incidents/r1/state')
+        .send({ state: 'closed', notes: 'Closing for test' })
+        .expect(200);
+
+      const response = await request(app)
+        .patch('/api/events/1/incidents/r1/reopen')
+        .send({ notes: 'Reopening for further review' })
+        .expect(200);
+
+      expect(response.body.incident).toBeDefined();
+      expect(response.body.incident.state).toBe('acknowledged');
+    });
+
+    it('should reopen a resolved incident to investigating when assignee provided and notes provided', async () => {
+      // Set r1 to resolved first
+      await request(app)
+        .patch('/api/events/1/incidents/r1/state')
+        .send({ state: 'resolved', notes: 'Resolving initially' })
+        .expect(200);
+
+      const response = await request(app)
+        .patch('/api/events/1/incidents/r1/reopen')
+        .send({ notes: 'Reopening and assigning', assignedToUserId: '1' })
+        .expect(200);
+
+      expect(response.body.incident.state).toBe('investigating');
+      expect(response.body.incident.assignedResponderId).toBe('1');
+    });
+
+    it('should require notes when reopening', async () => {
+      const response = await request(app)
+        .patch('/api/events/1/incidents/r1/reopen')
+        .send({})
+        .expect(400);
+
+      expect(response.body.error).toMatch(/Notes are required/i);
+    });
+
+    it('should forbid reporter from reopening', async () => {
+      // user id 2 as reporter without elevated roles
+      await request(app)
+        .patch('/api/events/1/incidents/r1/reopen')
+        .set('x-test-user-id', '2')
+        .send({ notes: 'Please reopen' })
+        .expect(403);
+    });
+
+    it('should only allow reopen from resolved or closed', async () => {
+      // Set to acknowledged first
+      await request(app)
+        .patch('/api/events/1/incidents/r1/state')
+        .send({ state: 'acknowledged', notes: 'Acknowledging for test' })
+        .expect(200);
+
+      await request(app)
+        .patch('/api/events/1/incidents/r1/reopen')
+        .send({ notes: 'Try to reopen from acknowledged' })
+        .expect(400);
+    });
+  });
+
   describe('API Validation', () => {
     test('should validate required fields for state change', async () => {
       const res = await request(app)

--- a/frontend/components/IncidentDetailView.tsx
+++ b/frontend/components/IncidentDetailView.tsx
@@ -103,6 +103,7 @@ export interface IncidentDetailViewProps {
   onDeleteConfirm?: (comment: Comment) => Promise<void>;
   onEditSave?: (comment: Comment, body?: string, visibility?: string, isMarkdown?: boolean) => Promise<{ success: boolean; error?: string }>;
   onStateChange?: (newState: string, notes?: string, assignedToUserId?: string) => Promise<void>;
+  onReopen?: (notes: string, assignedToUserId?: string) => Promise<{ success: boolean; error?: string }>;
   onDescriptionEdit?: (newDescription: string) => Promise<void>;
   onRelatedFileUpload?: (files: File[]) => void;
   onRelatedFileDelete?: (file: RelatedFile) => void;
@@ -140,6 +141,7 @@ export const IncidentDetailView: React.FC<IncidentDetailViewProps> = ({
   error = "",
   eventSlug,
   onEnhancedStateChange,
+  onReopen,
   onAssignmentChange = () => {},
   onCommentSubmit,
   onCommentEdit,
@@ -153,7 +155,8 @@ export const IncidentDetailView: React.FC<IncidentDetailViewProps> = ({
   apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000",
   onTitleEdit,
   onIncidentUpdate,
-  onTagsEdit
+  onTagsEdit,
+  onStateChange
 }) => {
   const isSystemAdmin = user && user.roles && user.roles.includes("system_admin");
   const isResponderOrAbove = userRoles.some((r) =>
@@ -429,11 +432,12 @@ export const IncidentDetailView: React.FC<IncidentDetailViewProps> = ({
             <StateManagementSection
               currentState={incident.state}
               allowedTransitions={getAllowedTransitions(incident.state)}
-              onStateChange={onEnhancedStateChange || (() => {})}
+              onStateChange={onStateChange || (() => {})}
               canChangeState={canChangeState}
               stateHistory={stateHistory}
               eventUsers={eventUsers}
               assignedResponderId={assignmentFields.assignedResponderId}
+              onReopen={onReopen}
             />
             <AssignmentSection
               assignmentFields={assignmentFields}

--- a/frontend/components/incident-detail/IncidentActions.tsx
+++ b/frontend/components/incident-detail/IncidentActions.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface User { id: string; name?: string; email?: string }
+
+interface IncidentActionsProps {
+  state: string;
+  isResponderOrAbove: boolean;
+  eventUsers: User[];
+  onReopen: (notes: string, assignedToUserId?: string) => Promise<{ success: boolean; error?: string }>;
+}
+
+const IncidentActions: React.FC<IncidentActionsProps> = ({ state, isResponderOrAbove, eventUsers, onReopen }) => {
+  const [open, setOpen] = useState(false);
+  const [notes, setNotes] = useState('');
+  const [assignee, setAssignee] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canReopen = isResponderOrAbove && (state === 'resolved' || state === 'closed');
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    setError(null);
+    const result = await onReopen(notes.trim(), assignee || undefined);
+    if (!result.success) {
+      setError(result.error || 'Failed to reopen');
+    } else {
+      setOpen(false);
+      setNotes('');
+      setAssignee('');
+    }
+    setSubmitting(false);
+  };
+
+  if (!canReopen) return null;
+
+  return (
+    <div className="mt-4">
+      <Button variant="default" onClick={() => setOpen(true)}>Reopen Incident</Button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-background text-foreground w-full max-w-md rounded-md shadow p-4">
+            <h2 className="text-lg font-semibold mb-2">Reopen Incident</h2>
+            <p className="text-sm text-muted-foreground mb-3">Provide a note explaining why this incident is being reopened. Optionally assign to a responder to move directly to Investigating; otherwise it will be set to Acknowledged.</p>
+            <label className="block text-sm font-medium mb-1" htmlFor="reopen-notes">Notes</label>
+            <textarea id="reopen-notes" className="w-full border rounded px-2 py-1 mb-2 bg-background text-foreground min-h-[80px]" value={notes} onChange={e => setNotes(e.target.value)} placeholder="Add context for reopening..." />
+            <label className="block text-sm font-medium mb-1" htmlFor="reopen-assignee">Assign to (optional)</label>
+            <select id="reopen-assignee" className="w-full border rounded px-2 py-1 mb-3 bg-background text-foreground" value={assignee} onChange={e => setAssignee(e.target.value)}>
+              <option value="">(unassigned)</option>
+              {eventUsers.map(u => (
+                <option key={u.id} value={u.id}>{u.name || u.email || 'Unknown'}</option>
+              ))}
+            </select>
+            {error && <div className="text-sm text-red-600 mb-2" role="alert">{error}</div>}
+            <div className="flex justify-end gap-2">
+              <Button variant="secondary" onClick={() => { setOpen(false); setError(null); }} disabled={submitting}>Cancel</Button>
+              <Button onClick={handleSubmit} disabled={submitting || notes.trim().length === 0}>{submitting ? 'Reopening...' : 'Reopen'}</Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default IncidentActions;

--- a/frontend/components/incident-detail/StateManagementSection.tsx
+++ b/frontend/components/incident-detail/StateManagementSection.tsx
@@ -33,6 +33,8 @@ interface StateManagementSectionProps {
   severity?: string;
   canEditSeverity?: boolean;
   onSeverityChange?: (severity: string) => void;
+  // New: Reopen handler
+  onReopen?: (notes: string, assignedToUserId?: string) => Promise<{ success: boolean; error?: string }> | void;
 }
 
 const STATE_CONFIGS = {
@@ -110,12 +112,20 @@ export function StateManagementSection({
   // Severity editing props
   severity = "",
   canEditSeverity = false,
-  onSeverityChange
+  onSeverityChange,
+  onReopen
 }: StateManagementSectionProps) {
   const [selectedTransition, setSelectedTransition] = useState<string>("");
   const [transitionNotes, setTransitionNotes] = useState<string>("");
   const [selectedAssignee, setSelectedAssignee] = useState<string>(assignedResponderId);
   const [showDialog, setShowDialog] = useState<boolean>(false);
+
+  // Reopen modal state
+  const [showReopenDialog, setShowReopenDialog] = useState<boolean>(false);
+  const [reopenNotes, setReopenNotes] = useState<string>("");
+  const [reopenAssignee, setReopenAssignee] = useState<string>("");
+  const [reopenSubmitting, setReopenSubmitting] = useState<boolean>(false);
+  const [reopenError, setReopenError] = useState<string>("");
   
   // Severity editing state
   const [editingSeverity, setEditingSeverity] = useState<boolean>(false);
@@ -172,6 +182,36 @@ export function StateManagementSection({
   const handleSeverityCancel = () => {
     setLocalSeverity(severity);
     setEditingSeverity(false);
+  };
+
+  const canShowReopen = canChangeState && (currentState === 'resolved' || currentState === 'closed');
+
+  const submitReopen = async () => {
+    if (!onReopen) {
+      setShowReopenDialog(false);
+      return;
+    }
+    if (!reopenNotes.trim()) {
+      setReopenError('Notes are required to reopen an incident.');
+      return;
+    }
+    setReopenSubmitting(true);
+    setReopenError("");
+    try {
+      const result = await onReopen(reopenNotes, reopenAssignee || undefined);
+      if (result && !result.success) {
+        setReopenError(result.error || 'Failed to reopen incident.');
+        setReopenSubmitting(false);
+        return;
+      }
+      setShowReopenDialog(false);
+      setReopenNotes("");
+      setReopenAssignee("");
+    } catch (e) {
+      setReopenError(e instanceof Error ? e.message : 'Failed to reopen incident.');
+    } finally {
+      setReopenSubmitting(false);
+    }
   };
 
   return (
@@ -304,7 +344,7 @@ export function StateManagementSection({
       </Card>
 
       {/* Available Actions */}
-      {canChangeState && allowedTransitions.length > 0 && (
+      {(canChangeState && (allowedTransitions.length > 0 || canShowReopen)) && (
         <Card className="p-4">
           <h4 className="font-medium mb-3">Available Actions</h4>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -337,6 +377,28 @@ export function StateManagementSection({
                 </Button>
               );
             })}
+
+            {/* Reopen Action, shown when state is resolved or closed */}
+            {canShowReopen && (
+              <Button
+                key="reopen"
+                variant="outline"
+                className="h-auto min-h-[120px] p-4 flex flex-col items-start gap-2 text-left whitespace-normal border-blue-300 hover:bg-blue-50"
+                onClick={() => setShowReopenDialog(true)}
+                disabled={loading}
+              >
+                <div className="flex items-center gap-2 w-full">
+                  <ArrowRight className="h-4 w-4 flex-shrink-0" />
+                  <span className="font-medium">Reopen</span>
+                </div>
+                <p className="text-xs text-muted-foreground text-left leading-relaxed break-words whitespace-normal w-full">
+                  Reopen this report with required notes. Optionally assign to a responder to move directly into investigation.
+                </p>
+                <div className="flex items-center gap-1 text-xs text-muted-foreground mt-auto pt-2">
+                  <FileText size={12} />
+                </div>
+              </Button>
+            )}
           </div>
         </Card>
       )}
@@ -400,58 +462,87 @@ export function StateManagementSection({
                 <AlertDialogTitle>Change Status to {getStateConfig(selectedTransition)?.label}</AlertDialogTitle>
               </div>
             </AlertDialogHeader>
-            <div className="space-y-4">
-              <p className="text-sm text-muted-foreground">
-                {requirements?.message}
-              </p>
-              
+            <div className="space-y-3">
               {requirements?.requiresNotes && (
                 <div>
-                  <label htmlFor="transitionNotes" className="block text-sm font-medium text-foreground mb-1">Notes</label>
+                  <label className="block text-sm font-medium mb-1">Notes</label>
                   <textarea
-                    id="transitionNotes"
+                    className="w-full border rounded p-2 min-h-[100px]"
+                    placeholder="Add notes explaining this change..."
                     value={transitionNotes}
                     onChange={(e) => setTransitionNotes(e.target.value)}
-                    className="w-full border p-2 rounded bg-background text-foreground"
-                    placeholder={requirements.requiresNotes ? 'Required' : 'Optional'}
                   />
+                  {!transitionNotes.trim() && (
+                    <div className="text-xs text-muted-foreground mt-1">Notes are required for this transition.</div>
+                  )}
                 </div>
               )}
-              
               {requirements?.requiresAssignment && (
                 <div>
-                  <label htmlFor="assignee" className="block text-sm font-medium text-foreground mb-1">Assign Responder</label>
+                  <label className="block text-sm font-medium mb-1">Assign to</label>
                   <select
-                    id="assignee"
+                    className="w-full border rounded p-2"
                     value={selectedAssignee}
                     onChange={(e) => setSelectedAssignee(e.target.value)}
-                    className="w-full border p-2 rounded bg-background text-foreground"
                   >
                     <option value="">Select a responder...</option>
-                    {eventUsers
-                      .filter(user => user.roles?.some((role: string) => 
-                        ['responder', 'event admin'].includes(role.toLowerCase())
-                      ))
-                      .map((user) => (
-                        <option key={user.id} value={user.id}>
-                          {user.name || user.email}
-                        </option>
-                      ))}
+                    {eventUsers.map(u => (
+                      <option key={u.id} value={u.id}>{u.name || u.email}</option>
+                    ))}
                   </select>
                 </div>
               )}
             </div>
             <AlertDialogFooter>
-              <AlertDialogCancel onClick={() => setShowDialog(false)}>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={handleConfirmTransition}
-                disabled={
-                  loading ||
-                  (requirements?.requiresNotes && !transitionNotes.trim()) ||
-                  (requirements?.requiresAssignment && !selectedAssignee)
-                }
-              >
-                {loading ? 'Processing...' : `Change to ${getStateConfig(selectedTransition)?.label}`}
+              <AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleConfirmTransition} disabled={loading}>Confirm</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+
+      {/* Reopen Dialog */}
+      {canShowReopen && (
+        <AlertDialog open={showReopenDialog} onOpenChange={setShowReopenDialog}>
+          <AlertDialogContent className="max-w-lg">
+            <AlertDialogHeader>
+              <div className="flex items-center gap-3">
+                <ArrowRight className="h-5 w-5" />
+                <AlertDialogTitle>Reopen Report</AlertDialogTitle>
+              </div>
+            </AlertDialogHeader>
+            <div className="space-y-3">
+              <div>
+                <label className="block text-sm font-medium mb-1">Notes (required)</label>
+                <textarea
+                  className="w-full border rounded p-2 min-h-[100px]"
+                  placeholder="Explain why this report is being reopened..."
+                  value={reopenNotes}
+                  onChange={(e) => setReopenNotes(e.target.value)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Assign to (optional)</label>
+                <select
+                  className="w-full border rounded p-2"
+                  value={reopenAssignee}
+                  onChange={(e) => setReopenAssignee(e.target.value)}
+                >
+                  <option value="">Keep current assignment</option>
+                  {eventUsers.map(u => (
+                    <option key={u.id} value={u.id}>{u.name || u.email}</option>
+                  ))}
+                </select>
+                <p className="text-xs text-muted-foreground mt-1">If assigned, the report will move to Investigating; otherwise it will move to Acknowledged.</p>
+              </div>
+              {reopenError && (
+                <div className="text-destructive text-sm">{reopenError}</div>
+              )}
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={reopenSubmitting}>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={submitReopen} disabled={reopenSubmitting}>
+                {reopenSubmitting ? 'Reopening...' : 'Reopen'}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
@@ -459,4 +550,6 @@ export function StateManagementSection({
       )}
     </div>
   );
-} 
+}
+
+export default StateManagementSection; 

--- a/frontend/pages/events/[eventSlug]/incidents/[incidentId]/index.tsx
+++ b/frontend/pages/events/[eventSlug]/incidents/[incidentId]/index.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { IncidentDetailView } from '../../../../../components/IncidentDetailView';
+import { AssignmentSection } from '@/components/incident-detail/AssignmentSection';
+import IncidentActions from '@/components/incident-detail/IncidentActions';
 
 // Define interfaces
 interface User {
@@ -267,12 +269,41 @@ export default function ReportDetail() {
         throw new Error(errorData.error || 'Failed to update incident state.');
       }
       const data = await res.json();
-      setIncident(prev => prev ? { ...prev, state: data.incident.state } : null);
+      setIncident(prev => prev ? { ...prev, state: data.incident.state, assignedResponderId: data.incident.assignedResponderId ?? prev.assignedResponderId } : null);
       if (data.history) {
         setStateHistory(prev => [...prev, data.history]);
       }
     } catch (err) {
       setStateChangeError(err instanceof Error ? err.message : 'State change failed');
+    } finally {
+      setIsStateChanging(false);
+    }
+  };
+
+  const handleReopen = async (notes: string, assignedToUserId?: string) => {
+    if (!eventSlug || !incidentId) return { success: false, error: 'Missing IDs' } as const;
+    setIsStateChanging(true);
+    setStateChangeError(null);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000'}/api/events/slug/${eventSlug}/incidents/${incidentId}/reopen`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ notes, assignedToUserId }),
+          credentials: 'include'
+        }
+      );
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to reopen incident.');
+      }
+      setIncident(prev => prev ? { ...prev, state: data.incident.state, assignedResponderId: data.incident.assignedResponderId ?? prev.assignedResponderId } : null);
+      return { success: true } as const;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to reopen incident.';
+      setStateChangeError(msg);
+      return { success: false, error: msg } as const;
     } finally {
       setIsStateChanging(false);
     }
@@ -499,37 +530,43 @@ const handleDescriptionEdit = async (newDescription: string): Promise<void> => {
   if (!user) return <div>User not authenticated.</div>;
 
   return (
-    <IncidentDetailView
-      incident={incident}
-      user={user as User}
-      userRoles={userRoles}
-      comments={comments}
-      relatedFiles={relatedFiles}
-      onCommentSubmit={handleCommentSubmit}
-      onEditSave={handleEditSave}
-      onDeleteConfirm={handleDeleteConfirm}
-      onStateChange={handleStateChange}
-      isStateChanging={isStateChanging}
-      stateChangeError={stateChangeError}
-      onAssignmentChange={handleAssignmentChange}
-      assignmentFields={assignmentFields}
-      setAssignmentFields={setAssignmentFields}
-      eventUsers={eventUsers}
-      assignmentLoading={assignmentLoading}
-      assignmentError={assignmentError}
-      assignmentSuccess={assignmentSuccess}
-      onTitleEdit={handleTitleEdit}
-      onDescriptionEdit={handleDescriptionEdit}
-      onRelatedFileUpload={handleRelatedFileUpload}
-      onRelatedFileDelete={handleRelatedFileDelete}
-      newRelatedFiles={newRelatedFiles}
-      setNewRelatedFiles={setNewRelatedFiles}
-      relatedFileUploadMsg={relatedFileUploadMsg}
-      uploadingRelatedFile={uploadingRelatedFile}
-      isResponderOrAbove={isResponderOrAbove}
-      apiBaseUrl={process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000"}
-      stateHistory={stateHistory}
-      eventSlug={eventSlug}
-    />
+    <>
+      <IncidentDetailView
+        incident={incident}
+        user={user as User}
+        userRoles={userRoles}
+        comments={comments}
+        relatedFiles={relatedFiles}
+        onCommentSubmit={handleCommentSubmit}
+        onEditSave={handleEditSave}
+        onDeleteConfirm={handleDeleteConfirm}
+        onStateChange={handleStateChange}
+        onReopen={handleReopen}
+        isStateChanging={isStateChanging}
+        stateChangeError={stateChangeError}
+        onAssignmentChange={handleAssignmentChange}
+        assignmentFields={assignmentFields}
+        setAssignmentFields={setAssignmentFields}
+        eventUsers={eventUsers}
+        assignmentLoading={assignmentLoading}
+        assignmentError={assignmentError}
+        assignmentSuccess={assignmentSuccess}
+        onTitleEdit={handleTitleEdit}
+        onDescriptionEdit={handleDescriptionEdit}
+        onRelatedFileUpload={handleRelatedFileUpload}
+        onRelatedFileDelete={handleRelatedFileDelete}
+        newRelatedFiles={newRelatedFiles}
+        setNewRelatedFiles={setNewRelatedFiles}
+        relatedFileUploadMsg={relatedFileUploadMsg}
+        uploadingRelatedFile={uploadingRelatedFile}
+        isResponderOrAbove={isResponderOrAbove}
+        apiBaseUrl={process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000"}
+        stateHistory={stateHistory}
+        eventSlug={eventSlug}
+        // Provide reopen handler down to StateManagementSection via IncidentDetailView
+        onIncidentUpdate={(updated) => setIncident(prev => prev ? { ...prev, ...updated } : updated)}
+      />
+      {/* Reopen is now integrated inside StateManagementSection actions */}
+    </>
   );
 }

--- a/website/docs/developer-docs/api/incidents.md
+++ b/website/docs/developer-docs/api/incidents.md
@@ -34,7 +34,21 @@ Incident endpoints handle the core functionality of incident reporting, manageme
 
 - **PATCH** `/api/events/:eventId/incidents/:incidentId/state`
 - **Role:** Admin, SystemAdmin, or Responder
-- **Body:** `{ state }` (or `{ status }` for compatibility)
+- **Body:** `{ state, notes?, assignedToUserId? }`
+  - Valid states: `submitted`, `acknowledged`, `investigating`, `resolved`, `closed`
+  - Requirements:
+    - `investigating`: requires `notes` and `assignedToUserId`
+    - `resolved`: requires `notes`
+- **Response:** `{ incident }`
+
+### Reopen Report (Resolved/Closed)
+
+- **PATCH** `/api/events/:eventId/incidents/:incidentId/reopen`
+- **Role:** Responder, Admin, or SystemAdmin
+- **Body:** `{ notes: string, assignedToUserId?: string }`
+  - Behavior:
+    - If `assignedToUserId` provided, incident transitions to `investigating`
+    - If not provided, incident transitions to `acknowledged`
 - **Response:** `{ incident }`
 
 ### Update Report Title
@@ -106,6 +120,11 @@ Incidents follow a defined state workflow:
 - **`investigating`** - Active investigation in progress (requires assignment)
 - **`resolved`** - Investigation complete, resolution documented
 - **`closed`** - Final state, incident fully processed
+
+Additional rules:
+- Changing to `investigating` requires notes and assignment
+- Changing to `resolved` requires notes
+- Reopen from `resolved`/`closed` requires notes; optional assignment determines target state
 
 ## 🔒 Permission Requirements
 

--- a/website/docs/user-guide/incident-states.md
+++ b/website/docs/user-guide/incident-states.md
@@ -116,6 +116,19 @@ graph TD
 - **Event Administrators**: Reopen if new information emerges
 - **System**: Maintain for audit and reporting purposes
 
+### Reopen (from Resolved/Closed)
+
+When new information emerges, authorized team members can reopen an incident:
+
+- **Where**: Incident detail page → State & Assignment section → Reopen
+- **Who**: Responder, Event Admin, or System Admin
+- **Requirements**:
+  - Notes are required explaining why the incident is being reopened
+  - Assignment is optional
+- **Behavior**:
+  - If an assignee is selected, the incident transitions to `Investigating`
+  - If no assignee is selected, the incident transitions to `Acknowledged`
+
 ## State Transition Rules
 
 ### Automatic Transitions

--- a/website/docs/user-guide/recent-updates.md
+++ b/website/docs/user-guide/recent-updates.md
@@ -4,6 +4,16 @@ sidebar_position: 2
 
 # Recent Updates
 
+## August 2025
+
+### ♻️ Reopen Incidents (New Feature)
+
+- Added a dedicated Reopen action to the Incident detail State & Assignment section
+- Notes are required; optional assignment determines target state:
+  - With assignee → moves to Investigating
+  - Without assignee → moves to Acknowledged
+- Available to Responder, Event Admin, and System Admin roles
+
 ## December 2024
 
 ### 💬 Enhanced Comment System (New Features)


### PR DESCRIPTION
Fixes #336
- Added a new endpoint to reopen incidents, allowing transitions from 'resolved' or 'closed' states.
- Introduced validation for required notes and optional assignment during the reopening process.
- Updated the frontend to include a Reopen action in the Incident detail view, integrating it with the StateManagementSection.
- Enhanced integration tests to cover reopening scenarios, ensuring proper state transitions and access control.
- Updated API documentation to reflect the new reopening feature and its requirements.
