### PR TITLE
feat(frontend): add Login links on all unauthenticated screens (issue #409)

### DIFF
--- a/frontend/__tests__/pages/profile.test.tsx
+++ b/frontend/__tests__/pages/profile.test.tsx
@@ -3,6 +3,28 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ProfilePage from "../../pages/profile";
 import { UserContext } from "../../pages/_app";
 import '@testing-library/jest-dom';
+import Link from "next/link";
+
+// Mock next/router for components that use useRouter (e.g., AccessDenied)
+const mockRouter = {
+  asPath: '/profile',
+  push: jest.fn(),
+  replace: jest.fn(),
+  back: jest.fn(),
+  pathname: '/profile',
+  query: {},
+  route: '/profile',
+  basePath: '',
+  isLocaleDomain: false,
+  events: { on: jest.fn(), off: jest.fn(), emit: jest.fn() },
+  isFallback: false,
+  isPreview: false,
+  isReady: true,
+};
+
+jest.mock('next/router', () => ({
+  useRouter: () => mockRouter,
+}));
 
 // Use the global User type from types.d.ts
 const mockUser: User = {
@@ -24,6 +46,19 @@ describe("ProfilePage", () => {
   
   afterEach(() => {
     jest.resetAllMocks();
+  });
+
+  it("shows login link when unauthenticated", () => {
+    render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <UserContext.Provider value={{ user: null, setUser } as any}>
+        <ProfilePage />
+      </UserContext.Provider>,
+    );
+    const loginLink = screen.getByRole('link', { name: /sign in to continue/i });
+    expect(loginLink).toHaveAttribute('href');
+    // Should include /login?next=
+    expect(loginLink.getAttribute('href') || '').toMatch(/^\/login\?next=/);
   });
 
   it("renders avatar and user info", () => {

--- a/frontend/pages/events/[eventSlug]/incidents/[incidentId]/index.tsx
+++ b/frontend/pages/events/[eventSlug]/incidents/[incidentId]/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { AccessDenied } from "@/components/shared/AccessDenied";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { IncidentDetailView } from '../../../../../components/IncidentDetailView';
@@ -140,7 +141,7 @@ export default function ReportDetail() {
           } else if (res.status === 404) {
             throw new Error("Incident not found.");
           } else if (res.status === 401) {
-            throw new Error("You must be logged in to view this incident.");
+            throw new Error("AUTH_REQUIRED");
           } else {
             throw new Error(`Failed to fetch incident: ${res.status}`);
           }
@@ -544,9 +545,24 @@ const handleDescriptionEdit = async (newDescription: string): Promise<void> => {
 
 
   if (loading) return <div>Loading incident...</div>;
+  if (fetchError === "AUTH_REQUIRED") {
+    return (
+      <AccessDenied
+        title="Please Log In"
+        message="You need to log in to view this incident."
+      />
+    );
+  }
   if (fetchError) return <div>Error: {fetchError}</div>;
   if (!incident) return <div>Incident not found.</div>;
-  if (!user) return <div>User not authenticated.</div>;
+  if (!user) {
+    return (
+      <AccessDenied
+        title="Please Log In"
+        message="You need to log in to view this incident."
+      />
+    );
+  }
 
   return (
     <>

--- a/frontend/pages/events/[eventSlug]/incidents/index.tsx
+++ b/frontend/pages/events/[eventSlug]/incidents/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useContext } from "react";
 import { useRouter } from "next/router";
 import { Card } from "../../../../components/ui/card";
+import { AccessDenied } from "@/components/shared/AccessDenied";
 import { UserContext } from "../../../_app";
 import { EnhancedIncidentList } from "../../../../components/incidents/EnhancedIncidentList";
 import { useLogger } from "../../../../hooks/useLogger";
@@ -71,10 +72,10 @@ export default function EventIncidentsPage() {
 
   if (!user) {
     return (
-      <Card className="max-w-7xl mx-auto p-4 sm:p-8 mt-8">
-        <h2 className="text-2xl font-bold mb-6">Event Incidents</h2>
-        <div className="text-gray-500 dark:text-gray-400">You must be logged in to view incidents.</div>
-      </Card>
+      <AccessDenied
+        title="Please Log In"
+        message="You need to log in to view incidents for this event."
+      />
     );
   }
 
@@ -89,12 +90,11 @@ export default function EventIncidentsPage() {
 
   if (accessDenied) {
     return (
-      <Card className="max-w-7xl mx-auto p-4 sm:p-8 mt-8">
-        <h2 className="text-2xl font-bold mb-6">Access Denied</h2>
-        <div className="text-gray-500 dark:text-gray-400">
-          You don&apos;t have permission to view all event reports. Only Responders and Admins can access this page.
-        </div>
-      </Card>
+      <AccessDenied
+        title="Access Denied"
+        message="You don’t have permission to view all event incidents. Only Responders and Admins can access this page."
+        showLoginButton={false}
+      />
     );
   }
 

--- a/frontend/pages/events/[eventSlug]/my-incidents.tsx
+++ b/frontend/pages/events/[eventSlug]/my-incidents.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useContext } from "react";
 import { useRouter } from "next/router";
 import { Card } from "../../../components/ui/card";
+import { AccessDenied } from "@/components/shared/AccessDenied";
 import { UserContext } from "../../_app";
 import { EnhancedIncidentList } from "../../../components/incidents/EnhancedIncidentList";
 
@@ -43,10 +44,10 @@ export default function MyEventIncidentsPage() {
 
   if (!user) {
     return (
-      <Card className="max-w-7xl mx-auto p-4 sm:p-8 mt-8">
-        <h2 className="text-2xl font-bold mb-6">My Incidents</h2>
-        <div className="text-gray-500 dark:text-gray-400">You must be logged in to view your incidents.</div>
-      </Card>
+      <AccessDenied
+        title="Please Log In"
+        message="You need to log in to view your incidents for this event."
+      />
     );
   }
 

--- a/frontend/pages/events/[eventSlug]/settings/tags.tsx
+++ b/frontend/pages/events/[eventSlug]/settings/tags.tsx
@@ -81,7 +81,7 @@ export default function EventTagsPage() {
             <div className="text-center">
               <p className="text-muted-foreground mb-4">You must be logged in to access tag management.</p>
               <Button asChild>
-                <Link href="/auth/login">Login</Link>
+                <Link href={`/login?next=${encodeURIComponent(router.asPath || '')}`}>Login</Link>
               </Button>
             </div>
           </CardContent>

--- a/frontend/pages/events/[eventSlug]/team/index.tsx
+++ b/frontend/pages/events/[eventSlug]/team/index.tsx
@@ -303,7 +303,7 @@ export default function EventTeam() {
   // Redirect to login if user is not authenticated
   useEffect(() => {
     if (user === null && !loading) {
-      router.push(`/login?redirect=${encodeURIComponent(router.asPath)}`);
+      router.push(`/login?next=${encodeURIComponent(router.asPath)}`);
     }
   }, [user, loading, router]);
 

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef, useState } from "react";
+import { AccessDenied } from "@/components/shared/AccessDenied";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { UserContext } from "./_app";
 import { useLogger } from "@/hooks/useLogger";
@@ -31,9 +32,10 @@ export default function ProfilePage() {
 
   if (!user) {
     return (
-      <div className="p-8 text-center">
-        You must be logged in to view your profile.
-      </div>
+      <AccessDenied
+        title="Please Log In"
+        message="You need to log in to view your profile."
+      />
     );
   }
 

--- a/frontend/pages/profile/events.tsx
+++ b/frontend/pages/profile/events.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext, useEffect } from 'react';
+import { AccessDenied } from '@/components/shared/AccessDenied';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -190,11 +191,10 @@ export default function ProfileEvents() {
 
   if (!user) {
     return (
-      <div className="min-h-screen bg-background py-8 px-4 transition-colors duration-200">
-        <Card className="w-full max-w-4xl mx-auto p-4 sm:p-8">
-          <p className="text-center text-muted-foreground">You must be logged in to view your events.</p>
-        </Card>
-      </div>
+      <AccessDenied
+        title="Please Log In"
+        message="You need to log in to view your events."
+      />
     );
   }
 


### PR DESCRIPTION
This implements issue #409 by ensuring all unauthenticated UI states include a clear Login link that preserves the intended destination via `?next=...`.

Changes
- Standardized unauthenticated views to use `AccessDenied` which auto-builds `/login?next=${currentPath}`
- Updated pages:
  - `frontend/pages/profile.tsx`
  - `frontend/pages/profile/events.tsx`
  - `frontend/pages/events/[eventSlug]/incidents/index.tsx`
  - `frontend/pages/events/[eventSlug]/my-incidents.tsx`
  - `frontend/pages/events/[eventSlug]/incidents/[incidentId]/index.tsx`
  - `frontend/pages/events/[eventSlug]/settings/tags.tsx` (fixed old `/auth/login` link to `/login?next=...`)
  - `frontend/pages/events/[eventSlug]/team/index.tsx` (changed redirect param to `next`)
- Added a unit test for unauthenticated Profile page to assert presence of the login link with `?next=`

Testing
- All frontend tests pass (19/19)
- All backend tests pass (39/39)

Notes
- Authorization-denied states hide the login button while still using `AccessDenied` for consistent UX.

🤖 This was generated by a bot. If you have questions, please contact the maintainers.