### PR TITLE
Hide OAuth buttons on register page unless providers are configured

### DIFF
--- a/frontend/__tests__/pages/register.test.tsx
+++ b/frontend/__tests__/pages/register.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import RegisterPage from '../../pages/register';
+import '@testing-library/jest-dom';
+
+// Mock next/router
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    prefetch: jest.fn(),
+    query: {},
+    asPath: '/register',
+  }),
+}));
+
+describe('Register page - OAuth visibility', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    global.fetch = originalFetch as any;
+  });
+
+  it('hides Google/GitHub buttons when providers are disabled', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ providers: { google: false, github: false } }),
+    } as any);
+
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Google/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/GitHub/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows Google button when Google is enabled', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ providers: { google: true, github: false } }),
+    } as any);
+
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Google/i)).toBeInTheDocument();
+      expect(screen.queryByText(/GitHub/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows both buttons when both providers are enabled', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ providers: { google: true, github: true } }),
+    } as any);
+
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Google/i)).toBeInTheDocument();
+      expect(screen.getByText(/GitHub/i)).toBeInTheDocument();
+    });
+  });
+});
+
+

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -5,6 +5,22 @@ import 'whatwg-fetch';
 // Mock fetch for tests that don't need real network calls
 global.fetch = jest.fn();
 
+// Polyfill ResizeObserver for tests (used by Radix UI components)
+class ResizeObserver {
+  callback;
+  constructor(callback) {
+    this.callback = callback;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof global.ResizeObserver === 'undefined') {
+  // @ts-ignore
+  global.ResizeObserver = ResizeObserver;
+}
+
 // Suppress specific console warnings during tests while preserving errors
 const originalWarn = console.warn;
 const originalError = console.error;

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -89,7 +89,7 @@ export default function Register() {
           const data = await response.json();
           setOauthProviders(data.providers);
         }
-      } catch (_) {
+      } catch {
         // ignore; default is no providers
       }
     };

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -61,6 +61,7 @@ export default function Register() {
   const [emailAvailable, setEmailAvailable] = useState<boolean | null>(null);
   const [checkingEmail, setCheckingEmail] = useState(false);
   const router = useRouter();
+  const [oauthProviders, setOauthProviders] = useState({ google: false, github: false });
 
   // Password strength calculation
   useEffect(() => {
@@ -76,6 +77,24 @@ export default function Register() {
     const score = Object.values(requirements).filter(Boolean).length;
     setPasswordStrength({ score, requirements });
   }, [formData.password]);
+
+  // Check OAuth provider availability (match login page behavior)
+  useEffect(() => {
+    const checkOAuthProviders = async () => {
+      try {
+        const response = await fetch(
+          (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000') + '/api/oauth-providers'
+        );
+        if (response.ok) {
+          const data = await response.json();
+          setOauthProviders(data.providers);
+        }
+      } catch (_) {
+        // ignore; default is no providers
+      }
+    };
+    checkOAuthProviders();
+  }, []);
 
   // Email availability check (debounced)
   useEffect(() => {
@@ -261,56 +280,52 @@ export default function Register() {
             </div>
           )}
 
-          {/* Social Login Options */}
-          <div className="flex flex-col gap-4">
-            <div className="grid grid-cols-2 gap-4">
-              <Button
-                variant="outline"
-                onClick={() => handleSocialLogin('google')}
-                className="w-full"
-                disabled={isLoading}
-              >
-                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-                  <path
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                    fill="#4285F4"
-                  />
-                  <path
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    fill="#34A853"
-                  />
-                  <path
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    fill="#FBBC05"
-                  />
-                  <path
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    fill="#EA4335"
-                  />
-                </svg>
-                Google
-              </Button>
-              <Button
-                variant="outline"
-                onClick={() => handleSocialLogin('github')}
-                className="w-full"
-                disabled={isLoading}
-              >
-                <Github className="mr-2 h-4 w-4" />
-                GitHub
-              </Button>
+          {/* Social Login Options (only if configured) */}
+          {(oauthProviders.google || oauthProviders.github) && (
+            <div className="flex flex-col gap-4">
+              <div className={`grid gap-4 ${(oauthProviders.google && oauthProviders.github) ? 'grid-cols-2' : 'grid-cols-1'}`}>
+                {oauthProviders.google && (
+                  <Button
+                    variant="outline"
+                    onClick={() => handleSocialLogin('google')}
+                    className="w-full"
+                    disabled={isLoading}
+                  >
+                    <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+                      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+                    </svg>
+                    Google
+                  </Button>
+                )}
+                {oauthProviders.github && (
+                  <Button
+                    variant="outline"
+                    onClick={() => handleSocialLogin('github')}
+                    className="w-full"
+                    disabled={isLoading}
+                  >
+                    <Github className="mr-2 h-4 w-4" />
+                    GitHub
+                  </Button>
+                )}
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Email Registration Form */}
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
+          {(oauthProviders.google || oauthProviders.github) && (
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t" />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-background px-2 text-muted-foreground">Or register with email</span>
+              </div>
             </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-background px-2 text-muted-foreground">Or register with email</span>
-            </div>
-          </div>
+          )}
 
           <form onSubmit={handleSubmit} className="space-y-4">
             {/* Full Name */}

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -89,9 +89,11 @@ export default function Register() {
           // Non-OK response: keep defaults (no providers)
           return;
         }
-        const data = await response.json().catch(() => null);
+        const data: unknown = await response.json().catch(() => null);
         // Validate shape defensively
-        const providers = data && typeof data === 'object' ? (data as any).providers : undefined;
+        const providers = (data && typeof data === 'object' && 'providers' in (data as Record<string, unknown>)
+          ? (data as { providers?: { google?: unknown; github?: unknown } }).providers
+          : undefined);
         const google = providers && typeof providers.google === 'boolean' ? providers.google : false;
         const github = providers && typeof providers.github === 'boolean' ? providers.github : false;
         setOauthProviders({ google, github });

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -85,10 +85,16 @@ export default function Register() {
         const response = await fetch(
           (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000') + '/api/oauth-providers'
         );
-        if (response.ok) {
-          const data = await response.json();
-          setOauthProviders(data.providers);
+        if (!response.ok) {
+          // Non-OK response: keep defaults (no providers)
+          return;
         }
+        const data = await response.json().catch(() => null);
+        // Validate shape defensively
+        const providers = data && typeof data === 'object' ? (data as any).providers : undefined;
+        const google = providers && typeof providers.google === 'boolean' ? providers.google : false;
+        const github = providers && typeof providers.github === 'boolean' ? providers.github : false;
+        setOauthProviders({ google, github });
       } catch {
         // ignore; default is no providers
       }


### PR DESCRIPTION
### **User description**
Fixes #425

- **frontend(register): hide Google/GitHub buttons unless configured via /api/oauth-providers (fix #425)**
- **frontend(register): simplify error handling for OAuth provider fetching**


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Hide OAuth buttons unless providers are configured

- Fetch OAuth provider availability from API endpoint

- Dynamically adjust layout based on available providers

- Simplify error handling for OAuth provider fetching


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Register Page Load"] --> B["Fetch OAuth Providers"]
  B --> C["Check Google/GitHub Config"]
  C --> D["Show/Hide OAuth Buttons"]
  D --> E["Dynamic Layout Adjustment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>register.tsx</strong><dd><code>Dynamic OAuth provider visibility and layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/pages/register.tsx

<ul><li>Added state to track OAuth provider availability<br> <li> Implemented API call to check configured providers<br> <li> Conditionally render OAuth buttons based on configuration<br> <li> Adjusted grid layout to handle single/dual provider display</ul>


</details>


  </td>
  <td><a href="https://github.com/mattstratton/conducky/pull/429/files#diff-c411107df0717a24e44ab2f2b4c5109ef6f96ad81f8208e9efd3bb96ac07ed0c">+61/-46</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

