### PR TITLE
Improve form feedback announcements

### DIFF
--- a/frontend/components/UserRegistrationForm.test.tsx
+++ b/frontend/components/UserRegistrationForm.test.tsx
@@ -26,7 +26,7 @@ describe("UserRegistrationForm", () => {
     expect(screen.getByRole("button", { name: /register/i })).toBeInTheDocument();
   });
 
-  it("shows error for invalid email", async () => {
+  it("shows error for invalid email and announces it to assistive technology", async () => {
     const { container } = render(<UserRegistrationForm {...baseProps} />);
     fireEvent.change(screen.getByLabelText(/name/i), { target: { value: "Test User" } });
     fireEvent.blur(screen.getByLabelText(/name/i));
@@ -39,8 +39,8 @@ describe("UserRegistrationForm", () => {
     const form = container.querySelector("form");
     if (!form) throw new Error("Form element not found");
     fireEvent.submit(form);
-    const errors = await screen.findAllByText(/please enter a valid email address/i);
-    expect(errors.length).toBeGreaterThan(0);
+    const error = await screen.findByRole("alert");
+    expect(error).toHaveTextContent(/please enter a valid email address/i);
   });
 
   it("shows error for password mismatch", async () => {
@@ -56,6 +56,14 @@ describe("UserRegistrationForm", () => {
     fireEvent.click(screen.getByRole("button", { name: /register/i }));
     const errors = await screen.findAllByText(/passwords do not match/i);
     expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("announces server errors and success messages", () => {
+    const { rerender } = render(<UserRegistrationForm {...baseProps} error="Registration failed" />);
+    expect(screen.getByRole("alert")).toHaveTextContent(/registration failed/i);
+
+    rerender(<UserRegistrationForm {...baseProps} error="" success="Registration complete" />);
+    expect(screen.getByRole("status")).toHaveTextContent(/registration complete/i);
   });
 
   it("calls onSubmit with valid data", async () => {

--- a/frontend/components/UserRegistrationForm.test.tsx
+++ b/frontend/components/UserRegistrationForm.test.tsx
@@ -39,8 +39,8 @@ describe("UserRegistrationForm", () => {
     const form = container.querySelector("form");
     if (!form) throw new Error("Form element not found");
     fireEvent.submit(form);
-    const error = await screen.findByRole("alert");
-    expect(error).toHaveTextContent(/please enter a valid email address/i);
+    const error = await screen.findByText(/please enter a valid email address/i);
+    expect(error).toHaveAttribute("role", "alert");
   });
 
   it("shows error for password mismatch", async () => {

--- a/frontend/components/UserRegistrationForm.tsx
+++ b/frontend/components/UserRegistrationForm.tsx
@@ -141,8 +141,16 @@ export const UserRegistrationForm: React.FC<UserRegistrationFormProps> = ({
             </FormItem>
           )}
         />
-        {error && <div className="text-red-600 mt-2">{error}</div>}
-        {success && <div className="text-green-700 font-semibold mt-2">{success}</div>}
+        {error && (
+          <div className="text-red-600 mt-2" role="alert">
+            {error}
+          </div>
+        )}
+        {success && (
+          <div className="text-green-700 font-semibold mt-2" role="status">
+            {success}
+          </div>
+        )}
         <Button
           type="submit"
           disabled={

--- a/frontend/components/ui/form.tsx
+++ b/frontend/components/ui/form.tsx
@@ -155,6 +155,7 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
+      role="alert"
       className={cn("text-[0.8rem] font-medium text-destructive", className)}
       {...props}
     >

--- a/frontend/components/ui/form.tsx
+++ b/frontend/components/ui/form.tsx
@@ -146,6 +146,7 @@ const FormMessage = React.forwardRef<
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField()
   const body = error ? String(error?.message ?? "") : children
+  const role = error ? "alert" : props.role
 
   if (!body) {
     return null
@@ -155,9 +156,9 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
-      role="alert"
       className={cn("text-[0.8rem] font-medium text-destructive", className)}
       {...props}
+      role={role}
     >
       {body}
     </p>


### PR DESCRIPTION
## Summary

This is a small accessibility improvement for form feedback announcements:

- adds `role="alert"` to shared form validation messages so new field errors are announced by screen readers
- adds `role="alert"` for registration-level server errors
- adds `role="status"` for registration success feedback
- updates registration form tests to cover the announced feedback

## Accessibility impact

Before this change, visible validation/server feedback could appear without being exposed as an immediate assistive-technology announcement. After this change, users relying on screen readers get the same feedback when registration errors or success messages appear.

This contributes to #254, especially the screen reader support / form validation feedback portion.

## Checks

- `npm test -- UserRegistrationForm.test.tsx --runInBand` ✅
- `npx tsc --noEmit` ⚠️ fails on existing unrelated test type errors in `KeyboardNavigationTest.test.tsx`, `CoCTeamList.test.tsx`, and `IncidentDetailView.test.tsx`.
